### PR TITLE
Fix f-string syntax error in agent details formatting

### DIFF
--- a/elevenlabs_mcp/server.py
+++ b/elevenlabs_mcp/server.py
@@ -498,7 +498,7 @@ def get_agent(agent_id: str) -> TextContent:
 
     return TextContent(
         type="text",
-        text=f"Agent Details: Name: {response.name}, Agent ID: {response.agent_id}, Voice Configuration: {voice_info}, Created At: {datetime.fromtimestamp(response.metadata.created_at_unix_secs).strftime("%Y-%m-%d %H:%M:%S")}",
+        text=f"Agent Details: Name: {response.name}, Agent ID: {response.agent_id}, Voice Configuration: {voice_info}, Created At: {datetime.fromtimestamp(response.metadata.created_at_unix_secs).strftime('%Y-%m-%d %H:%M:%S')}",
     )
 
 


### PR DESCRIPTION
Fixes a syntax error in the `get_agent` function where nested double quotes in an f-string were causing the server to crash on startup. Changed the inner double quotes in the strftime() call to single quotes to resolve the parsing error.

Before this fix, the MCP server would immediately crash with a SyntaxError: f-string: unmatched '(' when attempting to initialize.

closes #15 