### PR TITLE
Add outbound calling functionality with automatic provider detection

### DIFF
--- a/elevenlabs_mcp/server.py
+++ b/elevenlabs_mcp/server.py
@@ -822,8 +822,17 @@ def create_voice_from_preview(
     )
 
 
+def _get_phone_number_by_id(phone_number_id: str):
+    """Helper function to get phone number details by ID."""
+    phone_numbers = client.conversational_ai.phone_numbers.list()
+    for phone in phone_numbers:
+        if phone.phone_number_id == phone_number_id:
+            return phone
+    make_error(f"Phone number with ID {phone_number_id} not found.")
+
+
 @mcp.tool(
-    description="""Make an outbound call via Twilio using an ElevenLabs agent.
+    description="""Make an outbound call using an ElevenLabs agent. Automatically detects provider type (Twilio or SIP trunk) and uses the appropriate API.
 
     ⚠️ COST WARNING: This tool makes an API call to ElevenLabs which may incur costs. Only use when explicitly requested by the user.
 
@@ -841,13 +850,27 @@ def make_outbound_call(
     agent_phone_number_id: str,
     to_number: str,
 ) -> TextContent:
-    response = client.conversational_ai.twilio.outbound_call(
-        agent_id=agent_id,
-        agent_phone_number_id=agent_phone_number_id,
-        to_number=to_number,
-    )
+    # Get phone number details to determine provider type
+    phone_number = _get_phone_number_by_id(agent_phone_number_id)
+    
+    if phone_number.provider.lower() == "twilio":
+        response = client.conversational_ai.twilio.outbound_call(
+            agent_id=agent_id,
+            agent_phone_number_id=agent_phone_number_id,
+            to_number=to_number,
+        )
+        provider_info = "Twilio"
+    elif phone_number.provider.lower() == "sip_trunk":
+        response = client.conversational_ai.sip_trunk.outbound_call(
+            agent_id=agent_id,
+            agent_phone_number_id=agent_phone_number_id,
+            to_number=to_number,
+        )
+        provider_info = "SIP trunk"
+    else:
+        make_error(f"Unsupported provider type: {phone_number.provider}")
 
-    return TextContent(type="text", text=f"Outbound call initiated: {response}.")
+    return TextContent(type="text", text=f"Outbound call initiated via {provider_info}: {response}.")
 
 
 @mcp.tool(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,3 +62,14 @@ build-backend = "setuptools.build_meta"
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 addopts = "-v --cov=elevenlabs_mcp --cov-report=term-missing"
+
+[dependency-groups]
+dev = [
+    "build>=1.2.2.post1",
+    "fastmcp>=0.4.1",
+    "pre-commit>=3.6.2",
+    "pytest>=8.0.0",
+    "pytest-cov>=4.1.0",
+    "ruff>=0.3.0",
+    "twine>=6.1.0",
+]


### PR DESCRIPTION
- Implement make_outbound_call tool that detects Twilio vs SIP trunk
- Support for agent-based phone calls with conversation tracking
- Return detailed call information including conversation and call IDs
- Enhance phone number listing to show provider types and assignments

This fixes https://github.com/elevenlabs/elevenlabs-mcp/issues/40 too.