### PR TITLE
fix: apply base_dir check to absolute paths in resource handler

### DIFF
--- a/elevenlabs_mcp/server.py
+++ b/elevenlabs_mcp/server.py
@@ -161,18 +161,20 @@ def get_elevenlabs_resource(filename: str) -> Resource:
     candidate = Path(filename)
     base_dir = make_output_path(None, base_path)
 
+    base_dir_resolved = base_dir.resolve()
+
     if candidate.is_absolute():
-        file_path = candidate.resolve()
+        resolved_file = candidate.resolve()
     else:
-        base_dir_resolved = base_dir.resolve()
         resolved_file = (base_dir_resolved / candidate).resolve()
-        try:
-            resolved_file.relative_to(base_dir_resolved)
-        except ValueError:
-            make_error(
-                f"Resource path ({resolved_file}) is outside of allowed directory {base_dir_resolved}"
-            )
-        file_path = resolved_file
+
+    try:
+        resolved_file.relative_to(base_dir_resolved)
+    except ValueError:
+        make_error(
+            f"Resource path ({resolved_file}) is outside of allowed directory {base_dir_resolved}"
+        )
+    file_path = resolved_file
 
     if not file_path.exists():
         raise FileNotFoundError(f"Resource file not found: {filename}")

--- a/elevenlabs_mcp/server.py
+++ b/elevenlabs_mcp/server.py
@@ -41,6 +41,7 @@ from elevenlabs_mcp.utils import (
     handle_output_mode,
     handle_multiple_files_output_mode,
     get_output_mode_description,
+    resolve_resource_path,
 )
 
 from elevenlabs_mcp.convai import create_conversation_config, create_platform_settings
@@ -158,23 +159,8 @@ def get_elevenlabs_resource(filename: str) -> Resource:
     """
     Resource handler for ElevenLabs generated files.
     """
-    candidate = Path(filename)
     base_dir = make_output_path(None, base_path)
-
-    base_dir_resolved = base_dir.resolve()
-
-    if candidate.is_absolute():
-        resolved_file = candidate.resolve()
-    else:
-        resolved_file = (base_dir_resolved / candidate).resolve()
-
-    try:
-        resolved_file.relative_to(base_dir_resolved)
-    except ValueError:
-        make_error(
-            f"Resource path ({resolved_file}) is outside of allowed directory {base_dir_resolved}"
-        )
-    file_path = resolved_file
+    file_path = resolve_resource_path(filename, base_dir)
 
     if not file_path.exists():
         raise FileNotFoundError(f"Resource file not found: {filename}")

--- a/elevenlabs_mcp/utils.py
+++ b/elevenlabs_mcp/utils.py
@@ -246,6 +246,42 @@ def parse_location(api_residency: str | None) -> str:
         raise ValueError(f"ELEVENLABS_API_RESIDENCY must be one of {valid_options}")
 
     return origin_map[api_residency]
+
+
+def resolve_resource_path(filename: str, base_dir: Path) -> Path:
+    """
+    Resolve a resource filename to an absolute path, ensuring it falls within base_dir.
+
+    Both absolute and relative paths are validated against base_dir to prevent
+    path traversal attacks.
+
+    Args:
+        filename: The filename or path to resolve (absolute or relative).
+        base_dir: The base directory that the resolved path must fall within.
+
+    Returns:
+        Path: The resolved absolute path.
+
+    Raises:
+        ElevenLabsMcpError: If the resolved path is outside base_dir.
+    """
+    candidate = Path(filename)
+    base_dir_resolved = base_dir.resolve()
+
+    if candidate.is_absolute():
+        resolved_file = candidate.resolve()
+    else:
+        resolved_file = (base_dir_resolved / candidate).resolve()
+
+    try:
+        resolved_file.relative_to(base_dir_resolved)
+    except ValueError:
+        make_error(
+            f"Resource path ({resolved_file}) is outside of allowed directory {base_dir_resolved}"
+        )
+    return resolved_file
+
+
 def get_mime_type(file_extension: str) -> str:
     """
     Get MIME type for a given file extension.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,6 +11,7 @@ from elevenlabs_mcp.utils import (
     find_similar_filenames,
     try_find_similar_files,
     handle_input_file,
+    parse_location,
 )
 
 
@@ -145,3 +146,61 @@ def test_handle_input_file():
 
         with pytest.raises(ElevenLabsMcpError):
             handle_input_file(str(temp_path / "nonexistent.mp3"))
+
+
+def _resolve_resource_path(filename: str, base_dir: Path) -> Path:
+    """
+    Replicate the resource path resolution logic from server.py
+    to validate that absolute paths are checked against base_dir.
+    """
+    candidate = Path(filename)
+    base_dir_resolved = base_dir.resolve()
+
+    if candidate.is_absolute():
+        resolved_file = candidate.resolve()
+    else:
+        resolved_file = (base_dir_resolved / candidate).resolve()
+
+    try:
+        resolved_file.relative_to(base_dir_resolved)
+    except ValueError:
+        make_error(
+            f"Resource path ({resolved_file}) is outside of allowed directory {base_dir_resolved}"
+        )
+    return resolved_file
+
+
+def test_resource_path_absolute_inside_base_dir():
+    """Absolute path inside base_dir should succeed."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        base = Path(temp_dir)
+        test_file = base / "output.mp3"
+        test_file.touch()
+        result = _resolve_resource_path(str(test_file), base)
+        assert result == test_file.resolve()
+
+
+def test_resource_path_absolute_outside_base_dir():
+    """Absolute path outside base_dir must be rejected (path traversal fix)."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        base = Path(temp_dir)
+        with pytest.raises(ElevenLabsMcpError):
+            _resolve_resource_path("/etc/passwd", base)
+
+
+def test_resource_path_relative_traversal():
+    """Relative path with .. traversal must be rejected."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        base = Path(temp_dir)
+        with pytest.raises(ElevenLabsMcpError):
+            _resolve_resource_path("../../etc/passwd", base)
+
+
+def test_resource_path_relative_normal():
+    """Normal relative path inside base_dir should succeed."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        base = Path(temp_dir)
+        test_file = base / "audio.mp3"
+        test_file.touch()
+        result = _resolve_resource_path("audio.mp3", base)
+        assert result == test_file.resolve()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,7 +11,7 @@ from elevenlabs_mcp.utils import (
     find_similar_filenames,
     try_find_similar_files,
     handle_input_file,
-    parse_location,
+    resolve_resource_path,
 )
 
 
@@ -148,35 +148,13 @@ def test_handle_input_file():
             handle_input_file(str(temp_path / "nonexistent.mp3"))
 
 
-def _resolve_resource_path(filename: str, base_dir: Path) -> Path:
-    """
-    Replicate the resource path resolution logic from server.py
-    to validate that absolute paths are checked against base_dir.
-    """
-    candidate = Path(filename)
-    base_dir_resolved = base_dir.resolve()
-
-    if candidate.is_absolute():
-        resolved_file = candidate.resolve()
-    else:
-        resolved_file = (base_dir_resolved / candidate).resolve()
-
-    try:
-        resolved_file.relative_to(base_dir_resolved)
-    except ValueError:
-        make_error(
-            f"Resource path ({resolved_file}) is outside of allowed directory {base_dir_resolved}"
-        )
-    return resolved_file
-
-
 def test_resource_path_absolute_inside_base_dir():
     """Absolute path inside base_dir should succeed."""
     with tempfile.TemporaryDirectory() as temp_dir:
         base = Path(temp_dir)
         test_file = base / "output.mp3"
         test_file.touch()
-        result = _resolve_resource_path(str(test_file), base)
+        result = resolve_resource_path(str(test_file), base)
         assert result == test_file.resolve()
 
 
@@ -185,7 +163,7 @@ def test_resource_path_absolute_outside_base_dir():
     with tempfile.TemporaryDirectory() as temp_dir:
         base = Path(temp_dir)
         with pytest.raises(ElevenLabsMcpError):
-            _resolve_resource_path("/etc/passwd", base)
+            resolve_resource_path("/etc/passwd", base)
 
 
 def test_resource_path_relative_traversal():
@@ -193,7 +171,7 @@ def test_resource_path_relative_traversal():
     with tempfile.TemporaryDirectory() as temp_dir:
         base = Path(temp_dir)
         with pytest.raises(ElevenLabsMcpError):
-            _resolve_resource_path("../../etc/passwd", base)
+            resolve_resource_path("../../etc/passwd", base)
 
 
 def test_resource_path_relative_normal():
@@ -202,5 +180,5 @@ def test_resource_path_relative_normal():
         base = Path(temp_dir)
         test_file = base / "audio.mp3"
         test_file.touch()
-        result = _resolve_resource_path("audio.mp3", base)
+        result = resolve_resource_path("audio.mp3", base)
         assert result == test_file.resolve()


### PR DESCRIPTION
Fixes #92

## Problem

The `get_elevenlabs_resource` handler in `elevenlabs_mcp/server.py` (lines 164-165) allows absolute paths to bypass the `base_dir` restriction. When a URI like `elevenlabs:///etc/passwd` is provided, the handler resolves it as an absolute path and reads any file the process can access - the `relative_to()` check only runs for relative paths.

```python
if candidate.is_absolute():
    file_path = candidate.resolve()   # No base_dir check
```

## Fix

Moved `base_dir_resolved = base_dir.resolve()` before the branch and applied the `relative_to(base_dir_resolved)` check to both absolute and relative paths. The logic is now unified - both code paths resolve the candidate and then validate it falls within `base_dir`.

Changed in `elevenlabs_mcp/server.py`, lines 164-176.

## Tests

Added 4 tests to `tests/test_utils.py`:
- `test_resource_path_absolute_inside_base_dir` - absolute path within base_dir succeeds
- `test_resource_path_absolute_outside_base_dir` - absolute path outside base_dir raises `ElevenLabsMcpError`
- `test_resource_path_relative_traversal` - `../../etc/passwd` is rejected
- `test_resource_path_relative_normal` - normal relative path succeeds

All 16 tests pass (`uv run pytest tests/test_utils.py`).

This contribution was developed with AI assistance (Claude Code).