### PR TITLE
feat: add eu/in shorthand aliases for API residency

### DIFF
--- a/elevenlabs_mcp/utils.py
+++ b/elevenlabs_mcp/utils.py
@@ -231,7 +231,9 @@ def parse_location(api_residency: str | None) -> str:
     """
     origin_map = {
         "us": "https://api.elevenlabs.io",
+        "eu": "https://api.eu.residency.elevenlabs.io",
         "eu-residency": "https://api.eu.residency.elevenlabs.io",
+        "in": "https://api.in.residency.elevenlabs.io",
         "in-residency": "https://api.in.residency.elevenlabs.io",
         "global": "https://api.elevenlabs.io",
     }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,6 +11,7 @@ from elevenlabs_mcp.utils import (
     find_similar_filenames,
     try_find_similar_files,
     handle_input_file,
+    parse_location,
 )
 
 
@@ -145,3 +146,39 @@ def test_handle_input_file():
 
         with pytest.raises(ElevenLabsMcpError):
             handle_input_file(str(temp_path / "nonexistent.mp3"))
+
+
+def test_parse_location_shorthands():
+    """Test that 'eu' and 'in' shorthands resolve to the same URLs as their full forms."""
+    assert parse_location("eu") == "https://api.eu.residency.elevenlabs.io"
+    assert parse_location("in") == "https://api.in.residency.elevenlabs.io"
+    assert parse_location("eu") == parse_location("eu-residency")
+    assert parse_location("in") == parse_location("in-residency")
+
+
+def test_parse_location_existing_values():
+    """Existing residency values still work."""
+    assert parse_location("us") == "https://api.elevenlabs.io"
+    assert parse_location("global") == "https://api.elevenlabs.io"
+    assert parse_location("eu-residency") == "https://api.eu.residency.elevenlabs.io"
+    assert parse_location("in-residency") == "https://api.in.residency.elevenlabs.io"
+
+
+def test_parse_location_none_and_empty():
+    """None and empty strings default to US."""
+    assert parse_location(None) == "https://api.elevenlabs.io"
+    assert parse_location("") == "https://api.elevenlabs.io"
+    assert parse_location("   ") == "https://api.elevenlabs.io"
+
+
+def test_parse_location_case_insensitive():
+    """Shorthands are case-insensitive."""
+    assert parse_location("EU") == "https://api.eu.residency.elevenlabs.io"
+    assert parse_location("IN") == "https://api.in.residency.elevenlabs.io"
+    assert parse_location("  Eu  ") == "https://api.eu.residency.elevenlabs.io"
+
+
+def test_parse_location_invalid():
+    """Invalid values raise ValueError."""
+    with pytest.raises(ValueError):
+        parse_location("invalid")


### PR DESCRIPTION
Fixes #93

## Change

Adds `"eu"` and `"in"` as shorthand aliases in the `origin_map` dictionary in `elevenlabs_mcp/utils.py` (line 232). They resolve to the same URLs as `"eu-residency"` and `"in-residency"` respectively. Existing values are unchanged.

```python
origin_map = {
    "us": "https://api.elevenlabs.io",
    "eu": "https://api.eu.residency.elevenlabs.io",        # new
    "eu-residency": "https://api.eu.residency.elevenlabs.io",
    "in": "https://api.in.residency.elevenlabs.io",        # new
    "in-residency": "https://api.in.residency.elevenlabs.io",
    "global": "https://api.elevenlabs.io",
}
```

## Tests

Added 5 tests to `tests/test_utils.py`:
- `test_parse_location_shorthands` - `"eu"` and `"in"` resolve correctly and match full forms
- `test_parse_location_existing_values` - `"us"`, `"global"`, `"eu-residency"`, `"in-residency"` unchanged
- `test_parse_location_none_and_empty` - None/empty defaults to US
- `test_parse_location_case_insensitive` - `"EU"`, `"IN"`, `"  Eu  "` all work
- `test_parse_location_invalid` - invalid values still raise ValueError

All 17 tests pass (`uv run pytest tests/test_utils.py`).

This contribution was developed with AI assistance (Claude Code).