### PR TITLE
fix: extract resource path resolution helper, close traversal bypass

### DIFF
--- a/elevenlabs_mcp/server.py
+++ b/elevenlabs_mcp/server.py
@@ -41,6 +41,7 @@ from elevenlabs_mcp.utils import (
     handle_output_mode,
     handle_multiple_files_output_mode,
     get_output_mode_description,
+    resolve_resource_path,
 )
 
 from elevenlabs_mcp.convai import create_conversation_config, create_platform_settings
@@ -48,7 +49,6 @@ from elevenlabs.types.knowledge_base_locator import KnowledgeBaseLocator
 
 from elevenlabs.play import play
 from elevenlabs_mcp import __version__
-from pathlib import Path
 
 load_dotenv()
 api_key = os.getenv("ELEVENLABS_API_KEY")
@@ -158,21 +158,8 @@ def get_elevenlabs_resource(filename: str) -> Resource:
     """
     Resource handler for ElevenLabs generated files.
     """
-    candidate = Path(filename)
     base_dir = make_output_path(None, base_path)
-
-    if candidate.is_absolute():
-        file_path = candidate.resolve()
-    else:
-        base_dir_resolved = base_dir.resolve()
-        resolved_file = (base_dir_resolved / candidate).resolve()
-        try:
-            resolved_file.relative_to(base_dir_resolved)
-        except ValueError:
-            make_error(
-                f"Resource path ({resolved_file}) is outside of allowed directory {base_dir_resolved}"
-            )
-        file_path = resolved_file
+    file_path = resolve_resource_path(filename, base_dir)
 
     if not file_path.exists():
         raise FileNotFoundError(f"Resource file not found: {filename}")

--- a/elevenlabs_mcp/utils.py
+++ b/elevenlabs_mcp/utils.py
@@ -57,6 +57,23 @@ def make_output_path(
     return output_path
 
 
+def resolve_resource_path(filename: str, base_dir: Path) -> Path:
+    """Resolve a resource filename against base_dir, rejecting paths outside it."""
+    candidate = Path(filename)
+    base_dir_resolved = base_dir.resolve()
+    if candidate.is_absolute():
+        resolved_file = candidate.resolve()
+    else:
+        resolved_file = (base_dir_resolved / candidate).resolve()
+    try:
+        resolved_file.relative_to(base_dir_resolved)
+    except ValueError:
+        make_error(
+            f"Resource path ({resolved_file}) is outside of allowed directory {base_dir_resolved}"
+        )
+    return resolved_file
+
+
 def find_similar_filenames(
     target_file: str, directory: Path, threshold: int = 70
 ) -> list[tuple[str, int]]:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,6 +12,7 @@ from elevenlabs_mcp.utils import (
     try_find_similar_files,
     handle_input_file,
     parse_location,
+    resolve_resource_path,
 )
 
 
@@ -99,6 +100,32 @@ def test_make_output_path_relative_with_base():
         assert result == Path(temp_dir) / relative_subdir
         assert result.exists()
         assert result.is_dir()
+
+
+def test_resolve_resource_path_absolute_inside_base_dir(tmp_path):
+    target = tmp_path / "sub" / "file.mp3"
+    target.parent.mkdir()
+    target.write_bytes(b"x")
+    result = resolve_resource_path(str(target), tmp_path)
+    assert result == target.resolve()
+
+
+def test_resolve_resource_path_absolute_outside_base_dir(tmp_path):
+    outside = tmp_path.parent / "escape.txt"
+    with pytest.raises(ElevenLabsMcpError):
+        resolve_resource_path(str(outside), tmp_path)
+
+
+def test_resolve_resource_path_relative_traversal(tmp_path):
+    with pytest.raises(ElevenLabsMcpError):
+        resolve_resource_path("../escape.txt", tmp_path)
+
+
+def test_resolve_resource_path_relative_normal(tmp_path):
+    target = tmp_path / "ok.mp3"
+    target.write_bytes(b"x")
+    result = resolve_resource_path("ok.mp3", tmp_path)
+    assert result == target.resolve()
 
 
 def test_find_similar_filenames():


### PR DESCRIPTION
## Summary

Second attempt at #97 with @PaulAsjes's refactor request applied.

`get_elevenlabs_resource` in `elevenlabs_mcp/server.py` let an absolute path bypass the `base_dir` restriction: a URI like `elevenlabs:///etc/passwd` resolved to an arbitrary host file the MCP server process could read because the `relative_to(base_dir)` check only ran for relative paths.

The fix extracts the resolution into `resolve_resource_path(filename, base_dir)` in `elevenlabs_mcp/utils.py`. Both absolute and relative candidates get resolved and then validated against `base_dir.resolve()`. `get_elevenlabs_resource` calls the helper directly. Tests in `tests/test_utils.py` exercise the production helper rather than re-implementing the resolution logic.

Fixes #92. Thanks @kraenhansen for the re-engagement nudge and @PaulAsjes for the refactor direction.

## Tests

`uv run pytest tests/test_utils.py -v` -> 21 passed (4 new helper tests + 17 existing).

This contribution was developed with AI assistance (Claude Code).