### PR TITLE
feat: add simulate_conversation tool (#79)

### DIFF
--- a/elevenlabs_mcp/server.py
+++ b/elevenlabs_mcp/server.py
@@ -870,10 +870,11 @@ def simulate_conversation(
         for c in extra_evaluation_criteria:
             missing = [k for k in ("id", "name", "conversation_goal_prompt") if k not in c]
             if missing:
-                return make_error(
+                make_error(
                     f"Evaluation criterion missing fields {missing}. "
                     "Each criterion needs 'id', 'name', and 'conversation_goal_prompt'."
                 )
+                return TextContent(type="text", text="")
             criteria_objects.append(
                 PromptEvaluationCriteria(
                     id=c["id"],
@@ -896,7 +897,8 @@ def simulate_conversation(
             new_turns_limit=max_turns,
         )
     except Exception as e:
-        return make_error(f"Failed to simulate conversation: {str(e)}")
+        make_error(f"Failed to simulate conversation: {str(e)}")
+        return TextContent(type="text", text="")
 
     lines = ["## Simulated Conversation\n"]
 

--- a/elevenlabs_mcp/server.py
+++ b/elevenlabs_mcp/server.py
@@ -854,6 +854,8 @@ Transcript:
             - name (str): human label e.g. "Issue Resolved"
             - conversation_goal_prompt (str): the assertion to check
               e.g. "The agent fully resolved the user's issue."
+            - use_knowledge_base (bool, optional): whether the evaluator should
+              reference the agent's knowledge base when judging. Defaults to False.
         max_turns: Maximum conversation turns. Defaults to 10.
     """
 )
@@ -893,7 +895,7 @@ def simulate_conversation(
                     **({"first_message": first_message} if first_message else {}),
                 }
             },
-            extra_evaluation_criteria=criteria_objects if criteria_objects else None,
+            extra_evaluation_criteria=criteria_objects or None,
             new_turns_limit=max_turns,
         )
     except Exception as e:

--- a/elevenlabs_mcp/server.py
+++ b/elevenlabs_mcp/server.py
@@ -834,6 +834,7 @@ Transcript:
     
 
 @mcp.tool(
+    annotations=ToolAnnotations(destructiveHint=False, openWorldHint=True),
     description="""Simulate a text conversation between a conversational AI agent and a
     simulated user. Runs the full conversation and returns the transcript plus analysis.
 
@@ -878,21 +879,24 @@ def simulate_conversation(
                     id=c["id"],
                     name=c["name"],
                     conversation_goal_prompt=c["conversation_goal_prompt"],
-                    use_knowledge_base=False,
+                    use_knowledge_base=c.get("use_knowledge_base", False),
                 )
             )
 
-    response = client.conversational_ai.agents.simulate_conversation(
-        agent_id=agent_id,
-        simulation_specification={
-            "simulated_user_config": {
-                "prompt": simulated_user_prompt,
-                **({"first_message": first_message} if first_message else {}),
-            }
-        },
-        extra_evaluation_criteria=criteria_objects if criteria_objects else None,
-        new_turns_limit=max_turns,
-    )
+    try:
+        response = client.conversational_ai.agents.simulate_conversation(
+            agent_id=agent_id,
+            simulation_specification={
+                "simulated_user_config": {
+                    "prompt": simulated_user_prompt,
+                    **({"first_message": first_message} if first_message else {}),
+                }
+            },
+            extra_evaluation_criteria=criteria_objects if criteria_objects else None,
+            new_turns_limit=max_turns,
+        )
+    except Exception as e:
+        return make_error(f"Failed to simulate conversation: {str(e)}")
 
     lines = ["## Simulated Conversation\n"]
 
@@ -915,16 +919,14 @@ def simulate_conversation(
             lines.append(f"**Summary:** {summary}\n")
         call_successful = getattr(analysis, "call_successful", None)
         if call_successful:
-            icon = "✅" if call_successful == "success" else "❌"
-            lines.append(f"**Call result:** {icon} {call_successful}\n")
+            lines.append(f"**Call result:** {call_successful}\n")
         eval_results = getattr(analysis, "evaluation_criteria_results", {}) or {}
         if eval_results:
             lines.append("**Criteria results:**")
             for key, result in eval_results.items():
                 r = getattr(result, "result", "unknown")
                 rationale = getattr(result, "rationale", "")
-                icon = "✅" if r == "success" else "❌"
-                lines.append(f"  {icon} **{key}**: {r} — {rationale}")
+                lines.append(f"  **{key}**: {r} — {rationale}")
 
     return TextContent(type="text", text="\n".join(lines))
 

--- a/elevenlabs_mcp/server.py
+++ b/elevenlabs_mcp/server.py
@@ -50,6 +50,8 @@ from elevenlabs.types.knowledge_base_locator import KnowledgeBaseLocator
 from elevenlabs.play import play
 from elevenlabs_mcp import __version__
 
+from elevenlabs import PromptEvaluationCriteria
+
 load_dotenv()
 api_key = os.getenv("ELEVENLABS_API_KEY")
 base_path = os.getenv("ELEVENLABS_MCP_BASE_PATH")
@@ -829,7 +831,102 @@ Transcript:
         make_error(f"Failed to fetch conversation: {str(e)}")
         # satisfies type checker
         return TextContent(type="text", text="")
+    
 
+@mcp.tool(
+    description="""Simulate a text conversation between a conversational AI agent and a
+    simulated user. Runs the full conversation and returns the transcript plus analysis.
+
+    Use this to test agent behaviour, evaluate prompts, and catch failure modes without
+    a live call. The simulated user follows the persona you describe.
+
+    ⚠️ COST WARNING: This tool makes an API call to ElevenLabs which may incur costs.
+    Only use when explicitly requested by the user.
+
+    Args:
+        agent_id: ID of the agent to test. Use list_agents to find IDs.
+        simulated_user_prompt: Instructions for how the simulated user should behave.
+            Example: "You are a frustrated customer who cannot find the cancel button."
+        first_message: Optional opening message to kick off the conversation.
+        extra_evaluation_criteria: Optional list of dicts, each with:
+            - id (str): unique key e.g. "issue_resolved"
+            - name (str): human label e.g. "Issue Resolved"
+            - conversation_goal_prompt (str): the assertion to check
+              e.g. "The agent fully resolved the user's issue."
+        max_turns: Maximum conversation turns. Defaults to 10.
+    """
+)
+def simulate_conversation(
+    agent_id: str,
+    simulated_user_prompt: str,
+    first_message: str | None = None,
+    extra_evaluation_criteria: list[dict] | None = None,
+    max_turns: int = 10,
+) -> TextContent:
+    # Validate criteria fields early
+    criteria_objects = []
+    if extra_evaluation_criteria:
+        for c in extra_evaluation_criteria:
+            missing = [k for k in ("id", "name", "conversation_goal_prompt") if k not in c]
+            if missing:
+                return make_error(
+                    f"Evaluation criterion missing fields {missing}. "
+                    "Each criterion needs 'id', 'name', and 'conversation_goal_prompt'."
+                )
+            criteria_objects.append(
+                PromptEvaluationCriteria(
+                    id=c["id"],
+                    name=c["name"],
+                    conversation_goal_prompt=c["conversation_goal_prompt"],
+                    use_knowledge_base=False,
+                )
+            )
+
+    response = client.conversational_ai.agents.simulate_conversation(
+        agent_id=agent_id,
+        simulation_specification={
+            "simulated_user_config": {
+                "prompt": simulated_user_prompt,
+                **({"first_message": first_message} if first_message else {}),
+            }
+        },
+        extra_evaluation_criteria=criteria_objects if criteria_objects else None,
+        new_turns_limit=max_turns,
+    )
+
+    lines = ["## Simulated Conversation\n"]
+
+    # Transcript
+    history = getattr(response, "simulated_conversation", []) or []
+    for turn in history:
+        role = getattr(turn, "role", "unknown").capitalize()
+        message = getattr(turn, "message", None)
+        if message:
+            lines.append(f"**{role}:** {message}")
+        for tc in getattr(turn, "tool_calls", []) or []:
+            lines.append(f"  _(tool: {getattr(tc, 'tool_name', '?')})_")
+
+    # Analysis
+    analysis = getattr(response, "analysis", None)
+    if analysis:
+        lines.append("\n## Analysis\n")
+        summary = getattr(analysis, "transcript_summary", None)
+        if summary:
+            lines.append(f"**Summary:** {summary}\n")
+        call_successful = getattr(analysis, "call_successful", None)
+        if call_successful:
+            icon = "✅" if call_successful == "success" else "❌"
+            lines.append(f"**Call result:** {icon} {call_successful}\n")
+        eval_results = getattr(analysis, "evaluation_criteria_results", {}) or {}
+        if eval_results:
+            lines.append("**Criteria results:**")
+            for key, result in eval_results.items():
+                r = getattr(result, "result", "unknown")
+                rationale = getattr(result, "rationale", "")
+                icon = "✅" if r == "success" else "❌"
+                lines.append(f"  {icon} **{key}**: {r} — {rationale}")
+
+    return TextContent(type="text", text="\n".join(lines))
 
 @mcp.tool(
     annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=True),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -233,14 +233,14 @@ def test_handle_input_file():
 def test_simulate_conversation_bad_criteria_returns_error():
     """Missing fields in evaluation criteria should return an error without calling API."""
     with patch("elevenlabs_mcp.server.client") as mock_client:
-        result = simulate_conversation(
-            agent_id="agent_abc",
-            simulated_user_prompt="Be difficult.",
-            extra_evaluation_criteria=[{"id": "check"}],  # missing name + goal
-        )
-        assert "missing" in result.text.lower()
+        with pytest.raises(ElevenLabsMcpError, match="missing"):
+            simulate_conversation(
+                agent_id="agent_abc",
+                simulated_user_prompt="Be difficult.",
+                extra_evaluation_criteria=[{"id": "check"}], 
+            )
+        
         mock_client.conversational_ai.agents.simulate_conversation.assert_not_called()
-
 
 def test_simulate_conversation_formats_transcript():
     """Conversation turns should appear correctly in output."""
@@ -272,7 +272,7 @@ def test_simulate_conversation_formats_transcript():
         assert "I need help with billing." in result.text
         assert "I can help you with that." in result.text
         assert "Billing issue resolved." in result.text
-        assert "✅" in result.text
+        assert "success" in result.text
 
 
 def test_simulate_conversation_handles_empty_response():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import pytest
 from pathlib import Path
 import tempfile
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 from elevenlabs_mcp.utils import (
     ElevenLabsMcpError,
     make_error,
@@ -15,6 +15,7 @@ from elevenlabs_mcp.utils import (
     parse_location,
     resolve_resource_path,
 )
+from elevenlabs_mcp.server import simulate_conversation
 
 
 def test_make_error():
@@ -228,6 +229,65 @@ def test_handle_input_file():
 
         with pytest.raises(ElevenLabsMcpError):
             handle_input_file(str(temp_path / "nonexistent.mp3"))
+
+def test_simulate_conversation_bad_criteria_returns_error():
+    """Missing fields in evaluation criteria should return an error without calling API."""
+    with patch("elevenlabs_mcp.server.client") as mock_client:
+        result = simulate_conversation(
+            agent_id="agent_abc",
+            simulated_user_prompt="Be difficult.",
+            extra_evaluation_criteria=[{"id": "check"}],  # missing name + goal
+        )
+        assert "missing" in result.text.lower()
+        mock_client.conversational_ai.agents.simulate_conversation.assert_not_called()
+
+
+def test_simulate_conversation_formats_transcript():
+    """Conversation turns should appear correctly in output."""
+    with patch("elevenlabs_mcp.server.client") as mock_client:
+        user_turn = MagicMock()
+        user_turn.role = "user"
+        user_turn.message = "I need help with billing."
+        user_turn.tool_calls = []
+
+        agent_turn = MagicMock()
+        agent_turn.role = "agent"
+        agent_turn.message = "I can help you with that."
+        agent_turn.tool_calls = []
+
+        analysis = MagicMock()
+        analysis.transcript_summary = "Billing issue resolved."
+        analysis.call_successful = "success"
+        analysis.evaluation_criteria_results = {}
+
+        mock_response = MagicMock()
+        mock_response.simulated_conversation = [user_turn, agent_turn]
+        mock_response.analysis = analysis
+        mock_client.conversational_ai.agents.simulate_conversation.return_value = mock_response
+
+        result = simulate_conversation(
+            agent_id="agent_abc",
+            simulated_user_prompt="You are a customer with a billing question.",
+        )
+        assert "I need help with billing." in result.text
+        assert "I can help you with that." in result.text
+        assert "Billing issue resolved." in result.text
+        assert "✅" in result.text
+
+
+def test_simulate_conversation_handles_empty_response():
+    """Empty conversation history should not crash."""
+    with patch("elevenlabs_mcp.server.client") as mock_client:
+        mock_response = MagicMock()
+        mock_response.simulated_conversation = []
+        mock_response.analysis = None
+        mock_client.conversational_ai.agents.simulate_conversation.return_value = mock_response
+
+        result = simulate_conversation(
+            agent_id="agent_abc",
+            simulated_user_prompt="Do nothing.",
+        )
+        assert result.text is not None
 
 
 def test_parse_location_shorthands():


### PR DESCRIPTION
# Add simulate_conversation MCP Tool

## Summary

Adds a new simulate_conversation MCP tool that enables text-based simulation between an ElevenLabs agent and a configurable simulated user persona.

Closes #79.

Currently, testing agent prompts requires manually sending raw HTTP requests to the ElevenLabs simulate_conversation endpoint. This PR exposes that functionality as an MCP tool, allowing MCP clients to run conversational test scenarios directly.

## The tool supports

- configurable simulated user behavior
- optional evaluation criteria
- formatted transcript output
- pass/fail analysis in a single call

## Supported parameters:

- agent_id
- simulated_user_prompt
- first_message (optional)
- extra_evaluation_criteria (optional)
- max_turns (optional)

## Changes
- `server.py` => one new tool function
- `tests/test_utils.py` => 3 new tests (bad input validation, 
   transcript formatting, empty response handling)

## Usage example
> "Test my support agent with an angry customer who wants a refund. 
>  Check if the issue was resolved and if the agent stayed polite."
