### PR TITLE
fix: voice_clone uploads file contents instead of path strings (#62)

### DIFF
--- a/elevenlabs_mcp/server.py
+++ b/elevenlabs_mcp/server.py
@@ -517,7 +517,11 @@ def get_voice(voice_id: str) -> McpVoice:
 def voice_clone(
     name: str, files: list[str], description: str | None = None
 ) -> TextContent:
-    input_files = [str(handle_input_file(file).absolute()) for file in files]
+    input_files = []
+    for file in files:
+        file_path = handle_input_file(file)
+        with file_path.open("rb") as f:
+            input_files.append(f.read())
     voice = client.voices.ivc.create(
         name=name, description=description, files=input_files
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,11 @@
 import pytest
 from pathlib import Path
 import tempfile
+import os
+
+# server.py reads ELEVENLABS_API_KEY at import time; set a dummy value so
+# server-level tests can import it without a real key.
+os.environ.setdefault("ELEVENLABS_API_KEY", "test-key")
 
 
 @pytest.fixture

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from elevenlabs_mcp import server
+
+
+def test_voice_clone_uploads_file_bytes_not_paths(tmp_path):
+    """Regression test for #62: voice_clone must upload file contents, not path strings."""
+    audio = tmp_path / "sample.mp3"
+    audio.write_bytes(b"fake-audio-bytes")
+
+    mock_client = MagicMock()
+    voice = mock_client.voices.ivc.create.return_value
+    voice.name, voice.voice_id, voice.category, voice.description = (
+        "My Clone",
+        "abc123",
+        "cloned",
+        None,
+    )
+
+    with (
+        patch.object(server, "client", mock_client),
+        patch.object(server, "handle_input_file", lambda file: Path(file)),
+    ):
+        server.voice_clone(name="My Clone", files=[str(audio)])
+
+    _, kwargs = mock_client.voices.ivc.create.call_args
+    assert kwargs["files"] == [b"fake-audio-bytes"]
+    assert all(isinstance(f, bytes) for f in kwargs["files"])


### PR DESCRIPTION
Fixes #62.

## Problem

`voice_clone` passed file **path strings** to `client.voices.ivc.create(files=...)`:

```python
input_files = [str(handle_input_file(file).absolute()) for file in files]
```

So the SDK uploaded the path text rather than the audio contents, and the API rejected it with `File upload is corrupted. Please ensure it is playable audio.` As confirmed in the issue thread, this affects **all** files, not just `text_to_speech`-generated ones.

## Fix

Open each file and send its bytes, matching the existing pattern already used by `speech_to_text` and `isolate_audio` (`with file_path.open("rb")`). `handle_input_file` still performs the existence and audio-content validation.

## Test

Adds `tests/test_server.py` with a regression test that asserts `voice_clone` passes the file **bytes** (not path strings) to the SDK. It fails on the previous code and passes on the fix. `tests/conftest.py` gets a small addition so `server.py` (which reads `ELEVENLABS_API_KEY` at import) can be imported under test without a real key.

Verified locally: `ruff check`/`ruff format --check` clean and `pytest` green (22 passed).
