### PR TITLE
fix: voice_clone sends file contents instead of path strings

### DIFF
--- a/elevenlabs_mcp/server.py
+++ b/elevenlabs_mcp/server.py
@@ -11,6 +11,7 @@ Each tool that makes an API call is marked with a cost warning. Please follow th
 Tools without cost warnings in their description are free to use as they only read existing data.
 """
 
+import contextlib
 import httpx
 import os
 import sys
@@ -523,10 +524,13 @@ def get_voice(voice_id: str) -> McpVoice:
 def voice_clone(
     name: str, files: list[str], description: str | None = None
 ) -> TextContent:
-    input_files = [str(handle_input_file(file).absolute()) for file in files]
-    voice = client.voices.ivc.create(
-        name=name, description=description, files=input_files
-    )
+    with contextlib.ExitStack() as stack:
+        input_files = [
+            stack.enter_context(handle_input_file(file).open("rb")) for file in files
+        ]
+        voice = client.voices.ivc.create(
+            name=name, description=description, files=input_files
+        )
 
     return TextContent(
         type="text",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "python-dotenv==1.0.1",
     "pydantic>=2.12",
     "httpx==0.28.1",
+    "httpcore>=1.0.9",
     "elevenlabs>=2.56.0",
     "fuzzywuzzy==0.18.0",
     "python-Levenshtein>=0.25.0",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,88 @@
+import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+os.environ.setdefault("ELEVENLABS_API_KEY", "test-key")
+
+from elevenlabs_mcp import server  # noqa: E402
+from elevenlabs_mcp.utils import ElevenLabsMcpError  # noqa: E402
+
+
+def test_voice_clone_passes_open_file_objects_with_real_bytes(tmp_path):
+    audio_file_1 = tmp_path / "voice1.mp3"
+    audio_file_2 = tmp_path / "voice2.mp3"
+    audio_file_1.write_bytes(b"FAKEAUDIO1")
+    audio_file_2.write_bytes(b"FAKEAUDIO2")
+    read_payloads = []
+
+    def fake_create(name, description, files):
+        assert all(not isinstance(file, str) for file in files)
+        assert all(hasattr(file, "read") for file in files)
+        for file in files:
+            read_payloads.append(file.read())
+        return SimpleNamespace(
+            name=name,
+            voice_id="vid",
+            category="cloned",
+            description=description,
+        )
+
+    with patch.object(server, "client") as mock_client:
+        assert isinstance(mock_client, MagicMock)
+        mock_client.voices.ivc.create.side_effect = fake_create
+
+        result = server.voice_clone(
+            name="Test Voice",
+            files=[str(audio_file_1.resolve()), str(audio_file_2.resolve())],
+            description="sample description",
+        )
+
+    assert read_payloads == [b"FAKEAUDIO1", b"FAKEAUDIO2"]
+    assert "Voice cloned successfully" in result.text
+    assert "ID: vid" in result.text
+
+
+def test_voice_clone_single_file_closes_handle_after_call(tmp_path):
+    audio_file = tmp_path / "voice.mp3"
+    audio_file.write_bytes(b"FAKEAUDIO")
+    captured_handles = []
+
+    def fake_create(name, description, files):
+        captured_handles.extend(files)
+        return SimpleNamespace(
+            name=name,
+            voice_id="vid",
+            category="cloned",
+            description=description,
+        )
+
+    with patch.object(server, "client") as mock_client:
+        assert isinstance(mock_client, MagicMock)
+        mock_client.voices.ivc.create.side_effect = fake_create
+
+        server.voice_clone(
+            name="Test Voice",
+            files=[str(audio_file.resolve())],
+            description=None,
+        )
+
+    assert len(captured_handles) == 1
+    assert all(handle.closed for handle in captured_handles)
+
+
+def test_voice_clone_missing_file_does_not_call_sdk(tmp_path):
+    missing_file = tmp_path / "missing.mp3"
+
+    with patch.object(server, "client") as mock_client:
+        assert isinstance(mock_client, MagicMock)
+
+        with pytest.raises(ElevenLabsMcpError):
+            server.voice_clone(
+                name="Test Voice",
+                files=[str(missing_file.resolve())],
+                description=None,
+            )
+
+        mock_client.voices.ivc.create.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 
 [[package]]
@@ -297,7 +297,7 @@ wheels = [
 
 [[package]]
 name = "elevenlabs"
-version = "2.53.0"
+version = "2.59.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -307,19 +307,20 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/09/a9/5f1afc8d3649b303e6a0f1c317f37062694be4dd95daec99d73581ceee54/elevenlabs-2.53.0.tar.gz", hash = "sha256:4681561f12a72baffc451f5d9d14b915dffe7e3d9b007917a1b077859bc63866", size = 646150, upload-time = "2026-06-15T09:33:10.332Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/54/198bf4ab4ba88455466963c733473fbab6b3c34910807c71b412c4ee7220/elevenlabs-2.59.0.tar.gz", hash = "sha256:b05cc41636bef94172e1b9343b650f5cc5e543fc88afe06c12217e0120fd1238", size = 717248, upload-time = "2026-07-22T10:13:24.653Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/ab/56c99ee7701ab4c2c587637a32b2f9b0afbfe3373069c02ecf524f752e16/elevenlabs-2.53.0-py3-none-any.whl", hash = "sha256:c1cb3bce2134ddc42375de77d88a8154c92bef497593ece2634b23e616ef057e", size = 1752582, upload-time = "2026-06-15T09:33:08.258Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/6ed4f12b1451714972d38ce1c0df446414acdd08f08336fc298901b68e95/elevenlabs-2.59.0-py3-none-any.whl", hash = "sha256:cdd048dc380733f81ee512baa3e9b333c11f4f466aa84301b946fe5354a3b6da", size = 1902619, upload-time = "2026-07-22T10:13:22.582Z" },
 ]
 
 [[package]]
 name = "elevenlabs-mcp"
-version = "0.9.1"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "elevenlabs" },
     { name = "fastapi" },
     { name = "fuzzywuzzy" },
+    { name = "httpcore" },
     { name = "httpx" },
     { name = "mcp", extra = ["cli"] },
     { name = "pydantic" },
@@ -355,10 +356,11 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.0.3" },
-    { name = "elevenlabs", specifier = ">=2.53.0" },
+    { name = "elevenlabs", specifier = ">=2.56.0" },
     { name = "fastapi", specifier = "==0.109.2" },
     { name = "fastmcp", marker = "extra == 'dev'", specifier = "==0.4.1" },
     { name = "fuzzywuzzy", specifier = "==0.18.0" },
+    { name = "httpcore", specifier = ">=1.0.9" },
     { name = "httpx", specifier = "==0.28.1" },
     { name = "mcp", extras = ["cli"], specifier = ">=1.9.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = "==3.6.2" },
@@ -437,24 +439,24 @@ wheels = [
 
 [[package]]
 name = "h11"
-version = "0.14.0"
+version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f5/38/3af3d3633a34a3316095b39c8e8fb4853a28a536e55d347bd8d8e9a14b03/h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d", size = 100418, upload-time = "2022-09-25T15:40:01.519Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/04/ff642e65ad6b90db43e668d70ffb6736436c7ce41fcc549f4e9472234127/h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761", size = 58259, upload-time = "2022-09-25T15:39:59.68Z" },
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
 ]
 
 [[package]]
 name = "httpcore"
-version = "1.0.7"
+version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6a/41/d7d0a89eb493922c37d343b607bc1b5da7f5be7e383740b4753ad8943e90/httpcore-1.0.7.tar.gz", hash = "sha256:8551cb62a169ec7162ac7be8d4817d561f60e08eaa485234898414bb5a8a0b4c", size = 85196, upload-time = "2024-11-15T12:30:47.531Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/f5/72347bc88306acb359581ac4d52f23c0ef445b57157adedb9aee0cd689d2/httpcore-1.0.7-py3-none-any.whl", hash = "sha256:a3fff8f43dc260d5bd363d9f9cf1830fa3a458b332856f34282de498ed420edd", size = 78551, upload-time = "2024-11-15T12:30:45.782Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`voice_clone` passed resolved file *paths as strings* to `client.voices.ivc.create(...)` instead of the file contents:

```python
input_files = [str(handle_input_file(file).absolute()) for file in files]
voice = client.voices.ivc.create(name=name, description=description, files=input_files)
```

The SDK received path strings rather than audio data, which is why valid audio was reported as "corrupted" / "File upload failed". This change opens each resolved path in binary mode and passes the open file objects to the single `ivc.create` call, using `contextlib.ExitStack` so every handle is open for the call and closed afterward. This matches the pattern already used by `speech_to_text` and `isolate_audio`. The public tool signature (`name`, `files: list[str]`, `description`) and the return formatting are unchanged.

## Why this matters

This fixes #62, the confirmed root cause behind `voice_clone` rejecting valid audio. Because the SDK never saw real file bytes, the tool failed for any input, making instant voice cloning unusable via the MCP server.

## Testing

Adds `tests/test_server.py` covering the fixed behavior with a mocked client:

- happy path: two valid audio paths are passed to `ivc.create` as open file objects (not strings), and reading them yields the real file bytes
- the file handles are closed after the call (ExitStack cleanup)
- a missing path is rejected by `handle_input_file` before any SDK call is made

`pytest tests/test_server.py` -> 3 passed (run via `uv run`).

Fixes #62

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped bugfix to voice_clone file upload wiring plus tests; no auth or broad API surface changes beyond dependency pins.
> 
> **Overview**
> Fixes instant voice cloning by sending **actual audio bytes** to ElevenLabs instead of filesystem path strings, which caused valid samples to fail as corrupted uploads.
> 
> `voice_clone` now resolves each input path with `handle_input_file`, opens it in binary mode, and passes those file objects to `client.voices.ivc.create`, using `contextlib.ExitStack` so handles stay open for the SDK call and are closed afterward—aligned with other upload-style tools in the server.
> 
> Adds **`tests/test_server.py`** with mocked-client coverage for multi-file byte payloads, handle cleanup, and missing-file errors before any SDK call. **`pyproject.toml`** also pins **`httpcore>=1.0.9`** (with lockfile bumps for `elevenlabs` and related HTTP stack).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a02a44ceecc691888dbac21ed735e0df71995ffc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->