### PR TITLE
fix: tolerate unsubstituted ${user_config.output_dir} placeholder in base path

### DIFF
--- a/elevenlabs_mcp/utils.py
+++ b/elevenlabs_mcp/utils.py
@@ -1,4 +1,6 @@
 import os
+import re
+import sys
 import tempfile
 import base64
 from pathlib import Path
@@ -21,6 +23,22 @@ def make_error(error_text: str):
     raise ElevenLabsMcpError(error_text)
 
 
+_UNSUBSTITUTED_TEMPLATE_PATTERN = re.compile(r"^\s*(\$\{[^}\s]+\}|\{\{[^}\s]+\}\})\s*$")
+
+
+def looks_like_unsubstituted_template(value: str | None) -> bool:
+    """Return True when ``value`` is a placeholder like ``${...}`` or ``{{...}}``.
+
+    Plugin marketplaces (e.g. the Cowork wrapper) sometimes ship the raw
+    template through as a config value when substitution fails. Treating
+    such values as real paths leads to ``mkdir '${user_config.output_dir}'``
+    style ``ENOENT`` failures, so callers should fall back to a default.
+    """
+    if not value:
+        return False
+    return bool(_UNSUBSTITUTED_TEMPLATE_PATTERN.match(value))
+
+
 def is_file_writeable(path: Path) -> bool:
     if path.exists():
         return os.access(path, os.W_OK)
@@ -40,17 +58,32 @@ def make_output_file(
 def make_output_path(
     output_directory: str | None, base_path: str | None = None
 ) -> Path:
+    if looks_like_unsubstituted_template(base_path):
+        print(
+            f"Warning: ELEVENLABS_MCP_BASE_PATH looks like an unsubstituted "
+            f"template ({base_path!r}); falling back to $HOME/Desktop.",
+            file=sys.stderr,
+        )
+        base_path = None
+    if looks_like_unsubstituted_template(output_directory):
+        print(
+            f"Warning: output_directory looks like an unsubstituted "
+            f"template ({output_directory!r}); ignoring.",
+            file=sys.stderr,
+        )
+        output_directory = None
+
     # Use None as the default, and provide a default when an empty string is passed
     if not base_path:
         base_path = str(Path.home() / "Desktop")
-    
+
     if output_directory is None:
         output_path = Path(os.path.expanduser(base_path))
     elif os.path.isabs(output_directory):
         output_path = Path(os.path.expanduser(output_directory))
     else:
         output_path = Path(os.path.expanduser(base_path)) / Path(output_directory)
-    
+
     if not is_file_writeable(output_path):
         make_error(f"Directory ({output_path}) is not writeable")
     output_path.mkdir(parents=True, exist_ok=True)
@@ -267,6 +300,8 @@ def parse_location(api_residency: str | None) -> str:
         raise ValueError(f"ELEVENLABS_API_RESIDENCY must be one of {valid_options}")
 
     return origin_map[api_residency]
+
+
 def get_mime_type(file_extension: str) -> str:
     """
     Get MIME type for a given file extension.
@@ -332,7 +367,7 @@ def create_resource_response(
     """
     mime_type = get_mime_type(file_extension)
     if directory is not None:
-        full_path = (directory / filename)
+        full_path = directory / filename
         resource_uri = f"elevenlabs://{full_path.as_posix()}"
     else:
         resource_uri = generate_resource_uri(filename)
@@ -399,14 +434,18 @@ def handle_output_mode(
 
     elif output_mode == "resources":
         # Return as EmbeddedResource without saving to disk
-        return create_resource_response(file_data, filename, file_extension, directory=output_path)
+        return create_resource_response(
+            file_data, filename, file_extension, directory=output_path
+        )
 
     elif output_mode == "both":
         # Save to disk AND return as EmbeddedResource
         output_path.mkdir(parents=True, exist_ok=True)
         with open(full_file_path, "wb") as f:
             f.write(file_data)
-        return create_resource_response(file_data, filename, file_extension, directory=output_path)
+        return create_resource_response(
+            file_data, filename, file_extension, directory=output_path
+        )
 
     else:
         raise ValueError(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,6 +11,7 @@ from elevenlabs_mcp.utils import (
     find_similar_filenames,
     try_find_similar_files,
     handle_input_file,
+    looks_like_unsubstituted_template,
     parse_location,
     resolve_resource_path,
 )
@@ -71,11 +72,11 @@ def test_make_output_path_relative_no_base_path():
         # Create Desktop directory so the parent exists
         desktop_dir = mock_home / "Desktop"
         desktop_dir.mkdir()
-        
+
         with patch("elevenlabs_mcp.utils.Path.home", return_value=mock_home):
             relative_subdir = "test_subdir"
             expected = desktop_dir / relative_subdir
-            
+
             result = make_output_path(relative_subdir, None)
             assert result == expected
             assert result.exists()
@@ -100,6 +101,60 @@ def test_make_output_path_relative_with_base():
         assert result == Path(temp_dir) / relative_subdir
         assert result.exists()
         assert result.is_dir()
+
+
+def test_looks_like_unsubstituted_template_detects_dollar_brace():
+    assert looks_like_unsubstituted_template("${user_config.output_dir}")
+    assert looks_like_unsubstituted_template("  ${user_config.output_dir}  ")
+
+
+def test_looks_like_unsubstituted_template_detects_double_brace():
+    assert looks_like_unsubstituted_template("{{user_config.output_dir}}")
+
+
+def test_looks_like_unsubstituted_template_rejects_real_paths():
+    assert not looks_like_unsubstituted_template("/tmp/output")
+    assert not looks_like_unsubstituted_template("/tmp/$weird/dir")
+    assert not looks_like_unsubstituted_template("~/Desktop")
+    assert not looks_like_unsubstituted_template("")
+    assert not looks_like_unsubstituted_template(None)
+    # A path that merely contains a brace expression in the middle isn't a placeholder.
+    assert not looks_like_unsubstituted_template("/tmp/${x}/y")
+
+
+def test_make_output_path_unsubstituted_base_path_falls_back_to_default(capsys):
+    """Cowork plugin wrapper bug: literal '${user_config.output_dir}' must not crash."""
+    with tempfile.TemporaryDirectory() as temp_home:
+        mock_home = Path(temp_home)
+        desktop = mock_home / "Desktop"
+        desktop.mkdir()
+        with patch("elevenlabs_mcp.utils.Path.home", return_value=mock_home):
+            result = make_output_path(None, "${user_config.output_dir}")
+            assert result == desktop
+            assert result.exists()
+        stderr = capsys.readouterr().err
+        assert "unsubstituted" in stderr
+
+
+def test_make_output_path_unsubstituted_double_brace_base_path(capsys):
+    with tempfile.TemporaryDirectory() as temp_home:
+        mock_home = Path(temp_home)
+        desktop = mock_home / "Desktop"
+        desktop.mkdir()
+        with patch("elevenlabs_mcp.utils.Path.home", return_value=mock_home):
+            result = make_output_path(None, "{{user_config.output_dir}}")
+            assert result == desktop
+            assert result.exists()
+
+
+def test_make_output_path_unsubstituted_output_directory_is_ignored(capsys):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        result = make_output_path("${user_config.subdir}", temp_dir)
+        # output_directory dropped → falls back to using base_path alone
+        assert result == Path(temp_dir)
+        assert result.exists()
+        stderr = capsys.readouterr().err
+        assert "unsubstituted" in stderr
 
 
 def test_resolve_resource_path_absolute_inside_base_dir(tmp_path):


### PR DESCRIPTION
## Summary

Fixes #102.

When the ElevenLabs MCP is installed via the Cowork plugin marketplace, the wrapper sometimes ships `${user_config.output_dir}` through verbatim as `ELEVENLABS_MCP_BASE_PATH` (its template substitution layer doesn't fire). Every file-generating tool — `generate_tts`, `generate_music`, `generate_sound_effect` — then crashes with:

```
Error: ENOENT: no such file or directory, mkdir '${user_config.output_dir}'
```

before any API call is made.

The root cause is in the Cowork wrapper, but the MCP server can fail gracefully:

- New `looks_like_unsubstituted_template()` helper matches whole-string `${...}` / `{{...}}` placeholders (paths that merely contain `$` are unaffected).
- `make_output_path()` now treats such a value in either `base_path` or `output_directory` as missing, warns to stderr, and falls back to `$HOME/Desktop` — the same default used when the env var is unset.

The reporter's secondary issue (`missing_permissions music_generation` on Starter tier) is an account/plan concern, not a server bug, so it's out of scope here.

## Test plan

- [x] `uv run pytest tests/test_utils.py` — 27 passed, including 6 new tests covering `${...}`, `{{...}}`, the `output_directory` placeholder, and paths that legitimately contain `$`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)