### PR TITLE
ci: fix publish workflow so v0.11.0 (and future tags) can publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,10 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.14"
+          # Match the minimum supported version. 3.14 currently fails to
+          # import httpcore (see test.yml comment); the wheel is pure-Python
+          # so the build interpreter doesn't matter.
+          python-version: "3.11"
 
       - name: Install uv
         run: pip install uv
@@ -43,6 +46,8 @@ jobs:
           uv pip install --system -e ".[dev]"
 
       - name: Run tests
+        env:
+          ELEVENLABS_API_KEY: dummy
         run: |
           uv run pytest --cov=elevenlabs_mcp
 


### PR DESCRIPTION
## Summary
The publish workflow (`.github/workflows/publish.yml`) was failing on the v0.11.0 tag ([run 28800798000](https://github.com/elevenlabs/elevenlabs-mcp/actions/runs/28800798000/job/85403301639)) — tests crashed at collection time and the build/upload steps never ran, so **v0.11.0 is not yet on PyPI**.

This mirrors the two fixes already applied to `test.yml` in #116:

1. Set `ELEVENLABS_API_KEY: dummy` on the "Run tests" step. `tests/test_utils.py` imports `elevenlabs_mcp.server`, whose top-level init raises when the key is unset.
2. Pin the build interpreter to Python 3.11 (was 3.14). `httpcore==1.0.9` (latest) still fails to import on Python 3.14 (`typing.Union` setattr in `httpcore/__init__.py`). The wheel is pure-Python (`py3`), so the build interpreter doesn't affect the artifact.

## After merge
Re-run the failed publish run for the existing v0.11.0 tag:

```
gh run rerun 28800798000
```

## Test plan
- [ ] After merge, `gh run rerun 28800798000` completes successfully
- [ ] `elevenlabs-mcp==0.11.0` appears on PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)