### PR TITLE
docs: add Autohand Code MCP setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ mcp-name: io.github.elevenlabs/elevenlabs-mcp
 
 If you're using Windows, you will have to enable "Developer Mode" in Claude Desktop to use the MCP server. Click "Help" in the hamburger menu at the top left and select "Enable Developer Mode".
 
+## Autohand Code
+
+Register the published server with [Autohand Code](https://github.com/autohandai/code-cli/):
+
+```bash
+autohand mcp add ElevenLabs env ELEVENLABS_API_KEY=insert-your-api-key-here uvx elevenlabs-mcp
+```
+
+Add `--scope project` after `mcp add` to keep the registration in the current workspace.
+
 ## Other MCP clients
 
 For other clients like Cursor and Windsurf, run:
@@ -175,6 +185,5 @@ which uvx
 ```
 
 Once you obtain the absolute path (e.g., `/usr/local/bin/uvx`), update your configuration to use that path (e.g., `"command": "/usr/local/bin/uvx"`). This ensures that the correct executable is referenced.
-
 
 


### PR DESCRIPTION
## Summary

Add a direct Autohand Code command using ElevenLabs' published `uvx` server and required API key environment variable.

## Verification

- `ELEVENLABS_API_KEY=test uv run --python 3.12 pytest` — 30 passed
- `git diff --check`

The test key was a non-secret dummy value used only to satisfy module initialization.