### PR TITLE
fix: attach knowledge base using pydantic AgentConfig models

### DIFF
--- a/elevenlabs_mcp/server.py
+++ b/elevenlabs_mcp/server.py
@@ -15,6 +15,7 @@ import httpx
 import os
 import sys
 import base64
+from contextlib import ExitStack
 from datetime import datetime
 from io import BytesIO
 from typing import IO, Literal, Union, cast
@@ -680,50 +681,64 @@ def add_knowledge_base_to_agent(
 
     is_file_based = url is None
 
-    if url is not None:
-        response = client.conversational_ai.knowledge_base.documents.create_from_url(
-            name=knowledge_base_name,
-            url=url,
-        )
-    else:
-        if text is not None:
-            text_bytes = text.encode("utf-8")
-            text_io = BytesIO(text_bytes)
-            text_io.name = "text.txt"
-            text_io.content_type = "text/plain"
-            file = text_io
-        elif input_file_path is not None:
-            path = handle_input_file(
-                file_path=input_file_path, audio_content_check=False
+    with ExitStack() as stack:
+        if url is not None:
+            response = (
+                client.conversational_ai.knowledge_base.documents.create_from_url(
+                    name=knowledge_base_name,
+                    url=url,
+                )
             )
-            file = open(path, "rb")
+        else:
+            if text is not None:
+                text_bytes = text.encode("utf-8")
+                text_io = BytesIO(text_bytes)
+                text_io.name = "text.txt"
+                text_io.content_type = "text/plain"
+                file = text_io
+            elif input_file_path is not None:
+                path = handle_input_file(
+                    file_path=input_file_path, audio_content_check=False
+                )
+                file = stack.enter_context(open(path, "rb"))
+            else:
+                # Unreachable due to provided_params validation above
+                make_error("Must provide either a URL, a file, or text")
 
-        response = client.conversational_ai.knowledge_base.documents.create_from_file(
-            name=knowledge_base_name,
-            file=file,
-        )
+            response = (
+                client.conversational_ai.knowledge_base.documents.create_from_file(
+                    name=knowledge_base_name,
+                    file=file,
+                )
+            )
 
     agent = client.conversational_ai.agents.get(agent_id=agent_id)
+    conversation_config = agent.conversation_config
+    agent_config = conversation_config.agent
 
-    agent_config = agent.conversation_config.agent
-    knowledge_base_list = (
-        agent_config.get("prompt", {}).get("knowledge_base", []) if agent_config else []
-    )
-    knowledge_base_list.append(
-        KnowledgeBaseLocator(
-            type="file" if is_file_based else "url",
-            name=knowledge_base_name,
-            id=response.id,
+    if agent_config is None or agent_config.prompt is None:
+        make_error(
+            "Agent has no prompt configuration; cannot attach knowledge base. "
+            "Create or update the agent with a system prompt first."
         )
-    )
 
-    if agent_config and "prompt" not in agent_config:
-        agent_config["prompt"] = {}
-    if agent_config:
-        agent_config["prompt"]["knowledge_base"] = knowledge_base_list
+    locator = KnowledgeBaseLocator(
+        type="file" if is_file_based else "url",
+        name=knowledge_base_name,
+        id=response.id,
+    )
+    existing_kb = list(agent_config.prompt.knowledge_base or [])
+    existing_kb.append(locator)
+    updated_prompt = agent_config.prompt.model_copy(
+        update={"knowledge_base": existing_kb}
+    )
+    updated_agent = agent_config.model_copy(update={"prompt": updated_prompt})
+    updated_conversation_config = conversation_config.model_copy(
+        update={"agent": updated_agent}
+    )
 
     client.conversational_ai.agents.update(
-        agent_id=agent_id, conversation_config=agent.conversation_config
+        agent_id=agent_id, conversation_config=updated_conversation_config
     )
     return TextContent(
         type="text",
@@ -981,7 +996,7 @@ def list_conversations(
 
             conv_info = f"""Conversation ID: {conv.conversation_id}
 Status: {conv.status}
-Agent: {conv.agent_name or 'N/A'} (ID: {conv.agent_id})
+Agent: {conv.agent_name or "N/A"} (ID: {conv.agent_id})
 Started: {start_time}
 Duration: {conv.call_duration_secs} seconds
 Messages: {conv.message_count}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,179 @@
+import os
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from elevenlabs.types.agent_config import AgentConfig
+from elevenlabs.types.conversational_config import ConversationalConfig
+from elevenlabs.types.knowledge_base_locator import KnowledgeBaseLocator
+
+os.environ.setdefault("ELEVENLABS_API_KEY", "test-key")
+
+from elevenlabs_mcp import server  # noqa: E402
+from elevenlabs_mcp.utils import ElevenLabsMcpError  # noqa: E402
+
+
+def _agent_with_prompt(knowledge_base=None):
+    agent_config = AgentConfig(
+        prompt={
+            "prompt": "You are helpful.",
+            "llm": "gemini-2.0-flash-001",
+            "knowledge_base": knowledge_base or [],
+        }
+    )
+    conversation_config = ConversationalConfig(agent=agent_config)
+    return SimpleNamespace(
+        conversation_config=conversation_config,
+    )
+
+
+def test_add_knowledge_base_url_updates_pydantic_agent_config():
+    """SDK returns AgentConfig models; dict-style .get() previously crashed."""
+    captured = {}
+
+    def fake_update(agent_id, conversation_config):
+        captured["agent_id"] = agent_id
+        captured["conversation_config"] = conversation_config
+        return SimpleNamespace()
+
+    with patch.object(server, "client") as mock_client:
+        mock_client.conversational_ai.knowledge_base.documents.create_from_url.return_value = SimpleNamespace(
+            id="doc_url_1"
+        )
+        mock_client.conversational_ai.agents.get.return_value = _agent_with_prompt()
+        mock_client.conversational_ai.agents.update.side_effect = fake_update
+
+        result = server.add_knowledge_base_to_agent(
+            agent_id="agent_123",
+            knowledge_base_name="Docs",
+            url="https://example.com/kb",
+        )
+
+    assert "doc_url_1" in result.text
+    assert "agent_123" in result.text
+    assert captured["agent_id"] == "agent_123"
+
+    updated = captured["conversation_config"]
+    assert isinstance(updated, ConversationalConfig)
+    assert isinstance(updated.agent, AgentConfig)
+    kb = updated.agent.prompt.knowledge_base
+    assert len(kb) == 1
+    assert isinstance(kb[0], KnowledgeBaseLocator)
+    assert kb[0].id == "doc_url_1"
+    assert kb[0].type == "url"
+    assert kb[0].name == "Docs"
+
+
+def test_add_knowledge_base_preserves_existing_entries():
+    existing = [
+        KnowledgeBaseLocator(type="url", name="Old", id="doc_old"),
+    ]
+    captured = {}
+
+    def fake_update(agent_id, conversation_config):
+        captured["conversation_config"] = conversation_config
+        return SimpleNamespace()
+
+    with patch.object(server, "client") as mock_client:
+        mock_client.conversational_ai.knowledge_base.documents.create_from_url.return_value = SimpleNamespace(
+            id="doc_new"
+        )
+        mock_client.conversational_ai.agents.get.return_value = _agent_with_prompt(
+            knowledge_base=existing
+        )
+        mock_client.conversational_ai.agents.update.side_effect = fake_update
+
+        server.add_knowledge_base_to_agent(
+            agent_id="agent_123",
+            knowledge_base_name="New",
+            url="https://example.com/new",
+        )
+
+    kb = captured["conversation_config"].agent.prompt.knowledge_base
+    assert [item.id for item in kb] == ["doc_old", "doc_new"]
+
+
+def test_add_knowledge_base_text_source_uses_file_locator_type():
+    captured = {}
+
+    def fake_update(agent_id, conversation_config):
+        captured["conversation_config"] = conversation_config
+        return SimpleNamespace()
+
+    with patch.object(server, "client") as mock_client:
+        mock_client.conversational_ai.knowledge_base.documents.create_from_file.return_value = SimpleNamespace(
+            id="doc_text_1"
+        )
+        mock_client.conversational_ai.agents.get.return_value = _agent_with_prompt()
+        mock_client.conversational_ai.agents.update.side_effect = fake_update
+
+        server.add_knowledge_base_to_agent(
+            agent_id="agent_123",
+            knowledge_base_name="Notes",
+            text="hello knowledge",
+        )
+
+    locator = captured["conversation_config"].agent.prompt.knowledge_base[0]
+    assert locator.type == "file"
+    assert locator.id == "doc_text_1"
+    mock_client.conversational_ai.knowledge_base.documents.create_from_file.assert_called_once()
+
+
+def test_add_knowledge_base_file_path_closes_handle(tmp_path):
+    kb_file = tmp_path / "notes.txt"
+    kb_file.write_text("faq content")
+    captured_handles = []
+
+    def fake_create_from_file(name, file):
+        captured_handles.append(file)
+        assert not file.closed
+        assert file.read() == b"faq content"
+        file.seek(0)
+        return SimpleNamespace(id="doc_file_1")
+
+    with patch.object(server, "client") as mock_client:
+        mock_client.conversational_ai.knowledge_base.documents.create_from_file.side_effect = fake_create_from_file
+        mock_client.conversational_ai.agents.get.return_value = _agent_with_prompt()
+        mock_client.conversational_ai.agents.update.return_value = SimpleNamespace()
+
+        server.add_knowledge_base_to_agent(
+            agent_id="agent_123",
+            knowledge_base_name="FAQ",
+            input_file_path=str(kb_file.resolve()),
+        )
+
+    assert len(captured_handles) == 1
+    assert captured_handles[0].closed
+
+
+def test_add_knowledge_base_rejects_missing_prompt():
+    agent = SimpleNamespace(
+        conversation_config=ConversationalConfig(agent=AgentConfig(prompt=None))
+    )
+
+    with patch.object(server, "client") as mock_client:
+        mock_client.conversational_ai.knowledge_base.documents.create_from_url.return_value = SimpleNamespace(
+            id="doc_1"
+        )
+        mock_client.conversational_ai.agents.get.return_value = agent
+
+        with pytest.raises(ElevenLabsMcpError, match="prompt configuration"):
+            server.add_knowledge_base_to_agent(
+                agent_id="agent_123",
+                knowledge_base_name="Docs",
+                url="https://example.com/kb",
+            )
+
+        mock_client.conversational_ai.agents.update.assert_not_called()
+
+
+def test_add_knowledge_base_requires_exactly_one_source():
+    with patch.object(server, "client") as mock_client:
+        with pytest.raises(ElevenLabsMcpError, match="exactly one"):
+            server.add_knowledge_base_to_agent(
+                agent_id="agent_123",
+                knowledge_base_name="Docs",
+                url="https://example.com/kb",
+                text="also text",
+            )
+        mock_client.conversational_ai.knowledge_base.documents.create_from_url.assert_not_called()


### PR DESCRIPTION
## Summary

`add_knowledge_base_to_agent` creates a knowledge-base document successfully, then crashes when attaching it to the agent.

Root cause: the tool treated `agent.conversation_config.agent` as a plain `dict` (`.get(...)`, `"prompt" in ...`, `agent_config["prompt"] = ...`). With current `elevenlabs` SDK types this value is a pydantic `AgentConfig`, which has no `.get` and does not support item assignment. In practice the document could be created while the agent was never updated.

### What changed

- Read `AgentConfig` / prompt as pydantic models
- Append a `KnowledgeBaseLocator` via `model_copy` on prompt → agent → `ConversationalConfig`
- Pass the copied config into `agents.update`
- Fail clearly if the agent has no prompt configuration
- Close file-path uploads with `ExitStack` (previously left open handles)

Public tool signature and success message are unchanged.

## Why this matters

Without this fix, `add_knowledge_base_to_agent` is unusable against the current SDK: KB docs may be created, but attaching them to the agent raises `AttributeError` / `TypeError`. That breaks the common MCP workflow of creating an agent and then adding URL/file/text knowledge.

## Test plan

- [x] `uv run pytest tests/test_server.py` — 6 new tests covering:
  - URL source updates a real `AgentConfig` / `ConversationalConfig` (no dict `.get`)
  - existing knowledge-base entries are preserved
  - text source uses locator `type="file"`
  - file-path uploads are closed after `create_from_file`
  - missing prompt raises before `agents.update`
  - exactly-one-source validation still holds
- [x] `uv run pytest` — full suite green (36 passed)
- [x] `uv run ruff check` / `ruff format --check` on touched files

Manual (optional, needs API key): create an agent, call `add_knowledge_base_to_agent` with a URL, confirm `agents.get` shows the new KB locator.