### PR TITLE
chore: bump version to 0.12.1

### DIFF
--- a/elevenlabs_mcp/__init__.py
+++ b/elevenlabs_mcp/__init__.py
@@ -1,3 +1,3 @@
 """ElevenLabs MCP Server package."""
 
-__version__ = "0.12.0"
+__version__ = "0.12.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "elevenlabs-mcp"
-version = "0.12.0"
+version = "0.12.1"
 description = "ElevenLabs MCP Server"
 authors = [
     { name = "Jacek Duszenko", email = "jacek@elevenlabs.io" },

--- a/uv.lock
+++ b/uv.lock
@@ -463,7 +463,7 @@ wheels = [
 
 [[package]]
 name = "elevenlabs-mcp"
-version = "0.12.0"
+version = "0.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "elevenlabs" },


### PR DESCRIPTION
## Summary

- bump the package version from 0.12.0 to 0.12.1
- keep the runtime version and lockfile metadata in sync

## Testing

- 36 tests passed
- Ruff passed
- uv lock check passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only metadata change with no logic, API, or dependency updates.
> 
> **Overview**
> Bumps the **elevenlabs-mcp** release from `0.12.0` to **`0.12.1`** so packaging metadata matches the intended patch release.
> 
> Updates `__version__` in `elevenlabs_mcp/__init__.py`, the `version` field in `pyproject.toml`, and the editable package entry in `uv.lock`. No application or dependency version changes beyond that sync.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07d812a5abc06b91ba4210c17fe7c709d19b19d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->