### PR TITLE
chore: bump version to 0.12.2

### DIFF
--- a/elevenlabs_mcp/__init__.py
+++ b/elevenlabs_mcp/__init__.py
@@ -1,3 +1,3 @@
 """ElevenLabs MCP Server package."""
 
-__version__ = "0.12.1"
+__version__ = "0.12.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "elevenlabs-mcp"
-version = "0.12.1"
+version = "0.12.2"
 description = "ElevenLabs MCP Server"
 authors = [
     { name = "Jacek Duszenko", email = "jacek@elevenlabs.io" },

--- a/uv.lock
+++ b/uv.lock
@@ -463,7 +463,7 @@ wheels = [
 
 [[package]]
 name = "elevenlabs-mcp"
-version = "0.12.1"
+version = "0.12.2"
 source = { editable = "." }
 dependencies = [
     { name = "elevenlabs" },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Release metadata only; no runtime, API, or dependency changes in the diff.
> 
> **Overview**
> Bumps the package release version from **0.12.1** to **0.12.2** in `elevenlabs_mcp/__init__.py`, `pyproject.toml`, and the editable `elevenlabs-mcp` entry in `uv.lock`. No functional or dependency changes beyond aligning lock metadata with the new version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce625e949a5657e1075cdc5b061306ed0934b6b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->